### PR TITLE
Update node version in `engines` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack": "2.2.1"
   },
   "engines": {
-    "node": "4.2.1"
+    "node": ">=4.2.1"
   },
   "analyze": "true"
 }


### PR DESCRIPTION
I'm about to fix #12, which cause a headache for me when using this loader. This also blocks me from using with `lerna`, which I couldn't find an equivalent way to `-ignore-engines` flag

I've tested with the latest node version for a whole year & quite sure that this loader is also compatible with the recent versions of Node